### PR TITLE
feat(ignore): ignore dev, optional dependencies

### DIFF
--- a/.dev/.licrc
+++ b/.dev/.licrc
@@ -17,3 +17,5 @@ ignored=[]
 run_only_on_dependency_modification = false
 # False by default, if true, it will never block the build.
 do_not_block_pr = false
+do_not_show_dev_dependencies = false
+do_not_show_optional_dependencies = false

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -14,7 +14,6 @@
     "humao.rest-client",
     "davidanson.vscode-markdownlint",
     "github.vscode-pull-request-github",
-    "cschleiden.vscode-github-actions",
     "mikestead.dotenv",
     "codestream.codestream",
     "vadimcn.vscode-lldb",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -106,7 +106,7 @@ checksum = "3c4c54d47a4532db3494ef7332c257ab57b02750daae3250d49e01ee55201ce8"
 dependencies = [
  "semver",
  "serde",
- "toml",
+ "toml 0.5.8",
  "url",
 ]
 
@@ -353,9 +353,9 @@ dependencies = [
 
 [[package]]
 name = "futf"
-version = "0.1.4"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c9c1ce3fa9336301af935ab852c437817d14cd33690446569392e65170aac3b"
+checksum = "df420e2e84819663797d1ec6544b13c5be84629e7bb00dc960d6917db2987843"
 dependencies = [
  "mac",
  "new_debug_unreachable",
@@ -540,9 +540,9 @@ dependencies = [
 
 [[package]]
 name = "html2text"
-version = "0.4.2"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "617dbbb43af195e64f03eef3b9e412d8374764d88a554332624d83d782da7267"
+checksum = "8f0472a028e10a6a7c449d88c2caf30c4580fbfcb30affb4dc9491629f15e03f"
 dependencies = [
  "html5ever 0.26.0",
  "markup5ever 0.11.0",
@@ -742,7 +742,7 @@ checksum = "201de327520df007757c1f0adce6e827fe8562fbc28bfd9c15571c66ca1f5f79"
 
 [[package]]
 name = "licensebat-cli"
-version = "0.19.0"
+version = "0.20.0"
 dependencies = [
  "anyhow",
  "askalono",
@@ -758,7 +758,7 @@ dependencies = [
  "structopt",
  "thiserror",
  "tokio",
- "toml",
+ "toml 0.7.3",
  "tracing",
  "tracing-futures",
  "tracing-subscriber",
@@ -766,7 +766,7 @@ dependencies = [
 
 [[package]]
 name = "licensebat-core"
-version = "0.0.18"
+version = "0.0.20"
 dependencies = [
  "cargo-lock",
  "futures",
@@ -775,14 +775,14 @@ dependencies = [
  "serde_json",
  "serde_yaml",
  "thiserror",
- "toml",
+ "toml 0.7.3",
  "tracing",
  "yarn-lock-parser",
 ]
 
 [[package]]
 name = "licensebat-dart"
-version = "0.0.18"
+version = "0.0.20"
 dependencies = [
  "askalono",
  "futures",
@@ -798,7 +798,7 @@ dependencies = [
 
 [[package]]
 name = "licensebat-js"
-version = "0.0.19"
+version = "0.0.20"
 dependencies = [
  "futures",
  "licensebat-core",
@@ -813,7 +813,7 @@ dependencies = [
 
 [[package]]
 name = "licensebat-rust"
-version = "0.0.19"
+version = "0.0.20"
 dependencies = [
  "anyhow",
  "askalono",
@@ -827,7 +827,7 @@ dependencies = [
  "serde_json",
  "thiserror",
  "tokio",
- "toml",
+ "toml 0.7.3",
  "tracing",
 ]
 
@@ -894,9 +894,9 @@ dependencies = [
 
 [[package]]
 name = "matches"
-version = "0.1.9"
+version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3e378b66a060d48947b590737b30a1be76706c8dd7b8ba0f2fe3989c68a853f"
+checksum = "2532096657941c2fea9c289d370a250971c689d4f143798ff67113ec042024a5"
 
 [[package]]
 name = "memchr"
@@ -1047,9 +1047,9 @@ dependencies = [
 
 [[package]]
 name = "package-lock-json-parser"
-version = "0.1.1"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10a3900e84ea10eb5060ab7e3cb8215ea5687e3aaba12211a1e784169e01b895"
+checksum = "3e1d0e6260665ffbe7a64a8ed930ba53258da8c63061eeebe2158adacfca13ef"
 dependencies = [
  "serde",
  "serde_json",
@@ -1631,6 +1631,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_spanned"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0efd8caf556a6cebd3b285caf480045fcc1ac04f6bd786b09a6f11af30c4fcf4"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "serde_urlencoded"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1688,9 +1697,9 @@ checksum = "9def91fd1e018fe007022791f865d0ccc9b3a0d5001e01aabb8b40e46000afb5"
 
 [[package]]
 name = "smallvec"
-version = "1.7.0"
+version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ecab6c735a6bb4139c0caafd0cc3635748bbb3acf4550e8138122099251f309"
+checksum = "a507befe795404456341dfab10cef66ead4c041f62b8b11bbb92bffe5d0953e0"
 
 [[package]]
 name = "socket2"
@@ -1791,9 +1800,9 @@ dependencies = [
 
 [[package]]
 name = "tendril"
-version = "0.4.2"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9ef557cb397a4f0a5a3a628f06515f78563f2209e64d47055d9dc6052bf5e33"
+checksum = "d24a120c5fc464a3458240ee02c299ebcb9d67b5249c8848b09d639dca8d7bb0"
 dependencies = [
  "futf",
  "mac",
@@ -1928,6 +1937,40 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a31142970826733df8241ef35dc040ef98c679ab14d7c3e54d827099b3acecaa"
 dependencies = [
  "serde",
+]
+
+[[package]]
+name = "toml"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b403acf6f2bb0859c93c7f0d967cb4a75a7ac552100f9322faf64dc047669b21"
+dependencies = [
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_edit",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ab8ed2edee10b50132aed5f331333428b011c99402b5a534154ed15746f9622"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.19.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "239410c8609e8125456927e6707163a3b1fdb40561e4b803bc041f466ccfdc13"
+dependencies = [
+ "indexmap",
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "winnow",
 ]
 
 [[package]]
@@ -2284,6 +2327,15 @@ name = "windows_x86_64_msvc"
 version = "0.42.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "447660ad36a13288b1db4d4248e857b510e8c3a225c822ba4fb748c0aafecffd"
+
+[[package]]
+name = "winnow"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae8970b36c66498d8ff1d66685dc86b91b29db0c7739899012f63a63814b4b28"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "winreg"

--- a/licensebat-cli/Cargo.toml
+++ b/licensebat-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "licensebat-cli"
-version = "0.19.0"
+version = "0.20.0"
 authors = ["Roberto Huertas <roberto.huertas@outlook.com>"]
 description = "CLI tool to manage dependencies' license validation"
 edition = "2021"
@@ -19,10 +19,10 @@ path = "src/main.rs"
 
 [dependencies]
 # core libs
-licensebat-core = { path = "../licensebat-core", features = ["licrc-from-file"], version = "0.0.18" }
-licensebat-dart = { path = "../licensebat-dart", version = "0.0.18" }
-licensebat-js = { path = "../licensebat-js", version = "0.0.19" }
-licensebat-rust = { path = "../licensebat-rust", version = "0.0.19" }
+licensebat-core = { path = "../licensebat-core", features = ["licrc-from-file"], version = "0.0.20" }
+licensebat-dart = { path = "../licensebat-dart", version = "0.0.20" }
+licensebat-js = { path = "../licensebat-js", version = "0.0.20" }
+licensebat-rust = { path = "../licensebat-rust", version = "0.0.20" }
 # main dependencies
 tokio = { version = "1", features = ["rt-multi-thread", "macros", "fs"] }
 reqwest = "0.11"
@@ -35,7 +35,7 @@ structopt = "0.3.25"
 # serde
 serde = "1.0"
 serde_json = "1.0"
-toml = "0.5"
+toml = "0.7"
 # errors
 anyhow = "1.0"
 thiserror = "1.0"

--- a/licensebat-cli/README.md
+++ b/licensebat-cli/README.md
@@ -74,10 +74,28 @@ accepted = ["MIT", "MSC", "BSD"]
 [dependencies]
 # This will allow users to flag some dependencies so that Licensebat will not check for their license.
 ignored=["ignored_dep1", "ignored_dep2"]
+# False by default, if true it will mark all dev dependencies as ignored.
+# Bear in mind that this is only supported by some of the collectors.
+ignore_dev_dependencies = false
+# False by default, if true it will mark all optional dependencies as ignored.
+# Bear in mind that this is only supported by some of the collectors.
+ignore_optional_dependencies = false
 
 [behavior]
 # False by default (always exit code == 0), if true, it will exit with code 1 in case some invalid dependency is found.
 do_not_block_pr = false
+# False by default, if true it will do not show the ignored dependencies in the final report.
+do_not_show_ignored_dependencies = false
+# False by default, if true it will do not show the dev dependencies in the final report.
+# Bear in mind that this is only supported by some of the collectors.
+do_not_show_dev_dependencies = false
+# False by default, if true it will do not show the optional dependencies in the final report.
+# Bear in mind that this is only supported by some of the collectors.
+do_not_show_optional_dependencies = false
+# This will define the size of the buffer used to retrieve the dependencies.
+# It's set to 100 by default.
+# If you have a lot of dependencies, you might want to increase this value, but be careful, if the size is too big, the API might return an error.
+retriever_buffer_size = 100
 ```
 
 ## Logs

--- a/licensebat-cli/src/check.rs
+++ b/licensebat-cli/src/check.rs
@@ -68,41 +68,6 @@ pub async fn run(cli: Cli) -> anyhow::Result<RunResult> {
     ];
 
     // 4. get dependency stream
-    // TODO: this filter function is already calculating ingored dependencies.
-    // we're also doing it in the licrc validator. Ideally we should only do it once.
-    let filter = |dependency: &licensebat_core::Dependency| {
-        let is_dev = dependency.is_dev.unwrap_or_default();
-        let is_optional = dependency.is_optional.unwrap_or_default();
-
-        if licrc.behavior.do_not_show_dev_dependencies && is_dev {
-            return false;
-        }
-        if licrc.behavior.do_not_show_optional_dependencies && is_optional {
-            return false;
-        }
-
-        let is_ignored = licrc
-            .dependencies
-            .ignored
-            .as_ref()
-            .unwrap_or(&vec![])
-            .contains(&dependency.name);
-
-        if licrc.behavior.do_not_show_ignored_dependencies && is_ignored {
-            if is_ignored {
-                return false;
-            }
-            if licrc.dependencies.ignore_dev_dependencies && is_dev {
-                return false;
-            }
-            if licrc.dependencies.ignore_optional_dependencies && is_optional {
-                return false;
-            }
-        }
-
-        true
-    };
-
     let mut stream = file_collectors
         .iter()
         .find(|c| cli.dependency_file.contains(&c.get_dependency_filename()))

--- a/licensebat-cli/src/check.rs
+++ b/licensebat-cli/src/check.rs
@@ -72,7 +72,13 @@ pub async fn run(cli: Cli) -> anyhow::Result<RunResult> {
         .iter()
         .find(|c| cli.dependency_file.contains(&c.get_dependency_filename()))
         .and_then(|c| c.get_dependencies(&dep_file_content).ok())
-        .expect("No collector found for dependency file")
+        .expect(
+            format!(
+                "No collector found for dependency file {}",
+                cli.dependency_file
+            )
+            .as_str(),
+        )
         .buffer_unordered(licrc.behavior.retriever_buffer_size.unwrap_or(100));
 
     // 5. validate the dependencies according to the .licrc config

--- a/licensebat-cli/src/check.rs
+++ b/licensebat-cli/src/check.rs
@@ -71,7 +71,7 @@ pub async fn run(cli: Cli) -> anyhow::Result<RunResult> {
     let mut stream = file_collectors
         .iter()
         .find(|c| cli.dependency_file.contains(&c.get_dependency_filename()))
-        .and_then(|c| c.get_dependencies(&dep_file_content, &filter).ok())
+        .and_then(|c| c.get_dependencies(&dep_file_content, &licrc).ok())
         .expect(
             format!(
                 "No collector found for dependency file {}",

--- a/licensebat-cli/src/check.rs
+++ b/licensebat-cli/src/check.rs
@@ -87,6 +87,7 @@ pub async fn run(cli: Cli) -> anyhow::Result<RunResult> {
 
     while let Some(mut dependency) = stream.next().await {
         // don't process dev or optional dependencies if the user doesn't want to see them in the final report
+        // TODO: this should be done in the collector to avoid unnecessary requests.
         if (licrc.behavior.do_not_show_dev_dependencies && dependency.is_dev.unwrap_or_default())
             || licrc.behavior.do_not_show_optional_dependencies
                 && dependency.is_optional.unwrap_or_default()

--- a/licensebat-cli/src/main.rs
+++ b/licensebat-cli/src/main.rs
@@ -32,7 +32,7 @@ async fn main() -> anyhow::Result<()> {
     };
 
     // exit with 1 if there are invalid dependencies and the behavior is set to block PRs
-    if invalid_dependencies_count > 0 && !licrc.behavior.do_not_block_pr.unwrap_or(false) {
+    if invalid_dependencies_count > 0 && !licrc.behavior.do_not_block_pr {
         std::process::exit(1);
     }
     Ok(())

--- a/licensebat-core/Cargo.toml
+++ b/licensebat-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "licensebat-core"
-version = "0.0.18"
+version = "0.0.20"
 authors = ["Roberto Huertas <roberto.huertas@outlook.com>"]
 description = "Types and Traits for building Licensebat libraries"
 edition = "2021"
@@ -23,12 +23,12 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 serde_yaml = "0.9"
 yarn-lock-parser = "0.4.1"
-package-lock-json-parser = "0.1.1"
+package-lock-json-parser = "0.2.0"
 cargo-lock = "8.0.2"
 # utils
 futures = { version = "0.3.6" } 
 tracing = "0.1"
-toml = {version = "0.5", optional = true }
+toml = {version = "0.7", optional = true }
 # errors
 thiserror = "1.0.21"
 

--- a/licensebat-core/src/collector.rs
+++ b/licensebat-core/src/collector.rs
@@ -1,5 +1,6 @@
 //! Collector traits.
 use crate::dependency::RetrievedDependency;
+use crate::Dependency;
 use futures::stream::Stream;
 use futures::StreamExt;
 use futures::{future::BoxFuture, stream::Iter};
@@ -72,9 +73,15 @@ pub trait FileCollector: Collector {
     /// i.e. for npm package-lock.json, for rust cargo.lock
     fn get_dependency_filename(&self) -> String;
     /// Returns a stream of [`RetrievedDependency`] ready to be validated.
-    /// It accepts a &str with the content of the dependency file.
+    /// It accepts a &str with the content of the dependency file
+    /// and a function to filter the dependencies that we don't want to process,
+    /// mainly because the user has expressed the will to not to do so.
     /// # Errors
     ///
     /// Will return an [`Error`] if the parsing of the dependency file fails.
-    fn get_dependencies(&self, dependency_file_content: &str) -> RetrievedDependencyStreamResult;
+    fn get_dependencies(
+        &self,
+        dependency_file_content: &str,
+        filter_fn: &dyn Fn(&Dependency) -> bool,
+    ) -> RetrievedDependencyStreamResult;
 }

--- a/licensebat-core/src/collector.rs
+++ b/licensebat-core/src/collector.rs
@@ -1,5 +1,6 @@
 //! Collector traits.
 use crate::dependency::RetrievedDependency;
+use crate::licrc::LicRc;
 use crate::Dependency;
 use futures::stream::Stream;
 use futures::StreamExt;
@@ -82,6 +83,6 @@ pub trait FileCollector: Collector {
     fn get_dependencies(
         &self,
         dependency_file_content: &str,
-        filter_fn: &dyn Fn(&Dependency) -> bool,
+        licrc: &LicRc,
     ) -> RetrievedDependencyStreamResult;
 }

--- a/licensebat-core/src/collector.rs
+++ b/licensebat-core/src/collector.rs
@@ -1,7 +1,6 @@
 //! Collector traits.
 use crate::dependency::RetrievedDependency;
 use crate::licrc::LicRc;
-use crate::Dependency;
 use futures::stream::Stream;
 use futures::StreamExt;
 use futures::{future::BoxFuture, stream::Iter};

--- a/licensebat-core/src/dependency.rs
+++ b/licensebat-core/src/dependency.rs
@@ -2,7 +2,7 @@ use serde::{Deserialize, Serialize};
 use std::fmt::Debug;
 
 /// Generic and plain dependency without any extra information.
-/// Language agnostic, just holds the name and the version.
+/// Language agnostic, just holds the name and the version and some other information.
 #[derive(Serialize, Deserialize, Debug, Clone, Eq, Ord, PartialEq, PartialOrd, Default)]
 pub struct Dependency {
     /// Dependency name

--- a/licensebat-core/src/licrc.rs
+++ b/licensebat-core/src/licrc.rs
@@ -44,6 +44,8 @@ impl LicRc {
 }
 
 impl LicRc {
+    /// Checks if a dependency should be ignored or not.
+    /// Note that this function will set the dependency's `is_ignored` property to `true` if it's ignored.
     pub fn is_ignored(&self, dependency: &mut RetrievedDependency) -> bool {
         // is it explicitly ignored?
         if self
@@ -72,14 +74,15 @@ impl LicRc {
         false
     }
 
+    /// Checks if a dependency should be retrieved or not.
     pub fn filter_dependencies_before_retrieval(&self, dependency: &Dependency) -> bool {
         let is_dev = dependency.is_dev.unwrap_or_default();
         let is_optional = dependency.is_optional.unwrap_or_default();
 
-        if licrc.behavior.do_not_show_dev_dependencies && is_dev {
+        if self.behavior.do_not_show_dev_dependencies && is_dev {
             return false;
         }
-        if licrc.behavior.do_not_show_optional_dependencies && is_optional {
+        if self.behavior.do_not_show_optional_dependencies && is_optional {
             return false;
         }
 
@@ -94,10 +97,10 @@ impl LicRc {
             if is_ignored {
                 return false;
             }
-            if licrc.dependencies.ignore_dev_dependencies && is_dev {
+            if self.dependencies.ignore_dev_dependencies && is_dev {
                 return false;
             }
-            if licrc.dependencies.ignore_optional_dependencies && is_optional {
+            if self.dependencies.ignore_optional_dependencies && is_optional {
                 return false;
             }
         }

--- a/licensebat-core/src/licrc.rs
+++ b/licensebat-core/src/licrc.rs
@@ -137,6 +137,7 @@ pub struct LicRcDependencies {
     /// You must use the name of the dependency here.
     pub ignored: Option<Vec<String>>,
     /// If set to true, dev dependencies will be ignored.
+    #[serde(default)]
     pub ignore_dev_dependencies: bool,
     /// If set to true, optional dependencies will be ignored.
     #[serde(default)]

--- a/licensebat-core/src/licrc.rs
+++ b/licensebat-core/src/licrc.rs
@@ -64,17 +64,14 @@ impl LicRc {
         }
 
         // are dev dependencies ignored?
-        if self.dependencies.ignore_dev_dependencies.unwrap_or(false) {
+        if self.dependencies.ignore_dev_dependencies && dependency.is_dev.unwrap_or(false) {
             dependency.is_ignored = true;
             tracing::debug!(dependency = ?dependency, "Dependency has been ignored");
             return;
         }
 
         // are optional dependencies ignored?
-        if self
-            .dependencies
-            .ignore_optional_dependencies
-            .unwrap_or(false)
+        if self.dependencies.ignore_optional_dependencies && dependency.is_optional.unwrap_or(false)
         {
             dependency.is_ignored = true;
             tracing::debug!(dependency = ?dependency, "Dependency has been ignored");
@@ -140,22 +137,34 @@ pub struct LicRcDependencies {
     /// You must use the name of the dependency here.
     pub ignored: Option<Vec<String>>,
     /// If set to true, dev dependencies will be ignored.
-    pub ignore_dev_dependencies: Option<bool>,
+    pub ignore_dev_dependencies: bool,
     /// If set to true, optional dependencies will be ignored.
-    pub ignore_optional_dependencies: Option<bool>,
+    #[serde(default)]
+    pub ignore_optional_dependencies: bool,
 }
 
 /// Holds information about the behavior of the validation process.
 /// **This only applies for the [GITHUB API integrated project](https://github.com/marketplace/licensebat)**.
+#[allow(clippy::struct_excessive_bools)]
 #[derive(Serialize, Deserialize, Debug, Default, Clone)]
 pub struct LicRcBehavior {
     /// If set to false Licensebat will validate the dependencies no matter what file has been modified.
     /// If set to true, validation will only happen when one of the dependency files or the .licrc files has been modified in the commit.
     pub run_only_on_dependency_modification: Option<bool>,
     /// If set to true, Licensebat will execute the check but it won't block the PR.
-    pub do_not_block_pr: Option<bool>,
+    #[serde(default)]
+    pub do_not_block_pr: bool,
     /// This will define the size of the buffer used to retrieve the dependencies.
     /// It's set to 100 by default.
     /// If you have a lot of dependencies, you might want to increase this value, but be careful, if the size is too big, the API might return an error.
     pub retriever_buffer_size: Option<usize>,
+    /// If set to true, Licensebat will not show the ignored dependencies in the final report.
+    #[serde(default)]
+    pub do_not_show_ignored_dependencies: bool,
+    /// If set to true, Licensebat will not show the dev dependencies in the final report.
+    #[serde(default)]
+    pub do_not_show_dev_dependencies: bool,
+    /// If set to true, Licensebat will not show the optional dependencies in the final report.
+    #[serde(default)]
+    pub do_not_show_optional_dependencies: bool,
 }

--- a/licensebat-core/src/licrc.rs
+++ b/licensebat-core/src/licrc.rs
@@ -93,7 +93,7 @@ impl LicRc {
             .unwrap_or(&vec![])
             .contains(&dependency.name);
 
-        if self.behavior.do_not_show_ignored_dependencies && is_ignored {
+        if self.behavior.do_not_show_ignored_dependencies {
             if is_ignored {
                 return false;
             }

--- a/licensebat-dart/Cargo.toml
+++ b/licensebat-dart/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "licensebat-dart"
-version = "0.0.18"
+version = "0.0.20"
 edition = "2021"
 authors = ["Roberto Huertas <roberto.huertas@outlook.com>"]
 description = "A library to get information about your Dart dependencies"
@@ -16,7 +16,7 @@ maintenance = { status = "actively-developed" }
 
 [dependencies]
 # core
-licensebat-core = { path = "../licensebat-core", version = "0.0.18" }
+licensebat-core = { path = "../licensebat-core", version = "0.0.20" }
 # serialization
 serde = { version = "1.0", features = ["derive"] }
 serde_yaml = "0.9"

--- a/licensebat-dart/src/collector/dart_dependency.rs
+++ b/licensebat-dart/src/collector/dart_dependency.rs
@@ -34,6 +34,19 @@ impl TryInto<Dependency> for DartDependency {
     }
 }
 
+impl From<&DartDependency> for Dependency {
+    fn from(dependency: &DartDependency) -> Self {
+        let name = dependency.description.name.clone().unwrap_or(String::new());
+
+        Dependency {
+            name,
+            version: dependency.version.clone(),
+            is_dev: dependency.is_dev,
+            is_optional: dependency.is_optional,
+        }
+    }
+}
+
 #[derive(Serialize, Deserialize, Debug, Default, Clone)]
 pub struct Description {
     #[serde(default)]

--- a/licensebat-js/Cargo.toml
+++ b/licensebat-js/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "licensebat-js"
-version = "0.0.19"
+version = "0.0.20"
 edition = "2021"
 authors = ["Roberto Huertas <roberto.huertas@outlook.com>"]
 description = "A library to get information about your JS/TS dependencies"
@@ -15,7 +15,7 @@ maintenance = { status = "actively-developed" }
 
 [dependencies]
 # core
-licensebat-core = { path = "../licensebat-core", version = "0.0.18" }
+licensebat-core = { path = "../licensebat-core", version = "0.0.20" }
 # serialization
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
@@ -24,7 +24,7 @@ futures = { version = "0.3.6" }
 tracing = "0.1"
 reqwest = { version = "0.11.1", features = ["json"] }
 yarn-lock-parser = "0.4.1"
-package-lock-json-parser = "0.1.1"
+package-lock-json-parser = "0.2.0"
 
 [dev-dependencies]
 tokio = { version = "1", features = ["macros"] }

--- a/licensebat-rust/Cargo.toml
+++ b/licensebat-rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "licensebat-rust"
-version = "0.0.19"
+version = "0.0.20"
 edition = "2021"
 authors = ["Roberto Huertas <roberto.huertas@outlook.com>"]
 description = "A library to get information about your Rust dependencies"
@@ -15,12 +15,12 @@ maintenance = { status = "actively-developed" }
 
 [dependencies]
 # core
-licensebat-core = { path = "../licensebat-core", version = "0.0.18" }
+licensebat-core = { path = "../licensebat-core", version = "0.0.20" }
 # serialization
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 cargo-lock = "8.0.2"
-toml = "0.5"
+toml = "0.7"
 # utils
 futures = "0.3.6" 
 tracing = "0.1"
@@ -29,7 +29,7 @@ thiserror = "1.0"
 anyhow = "1.0"
 # docs rs
 easy-scraper = "0.2.0"
-html2text = "0.4.2"
+html2text = "0.5.0"
 askalono = "0.4.4"
 
 [dev-dependencies]


### PR DESCRIPTION
This PR allows the user to ignore dev and optional dependencies. Not only that, it also allows the user to not see neither the dev nor the optional dependencies.

There are new options available and documented in the .licrc file.

Bumped all versions.